### PR TITLE
Replace summary report with the text report

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha test/*.spec.js",
-    "coverage": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha",
+    "coverage": "./node_modules/.bin/istanbul cover --report lcov --report text --print none ./node_modules/.bin/_mocha",
     "travis-ci": "./node_modules/.bin/istanbul cover ./node_modules/.bin/_mocha && ./node_modules/.bin/istanbul-coveralls;"
   }
 }


### PR DESCRIPTION
Keep the default lcov report. To see the html report, `npm run coverage && open coverage/lcov-report/index.html`
